### PR TITLE
Filter out data with type = dg in Indicator.all

### DIFF
--- a/src/models/Indicator.ts
+++ b/src/models/Indicator.ts
@@ -25,6 +25,7 @@ export const all = (filter?: Filter): Promise<Indicator[]> =>
     .from("agg_data")
     .leftJoin("ind", "agg_data.ind_id", "ind.id")
     .where("include", 1)
+    .whereNot("type", "dg")
     .modify(withFilter, filter);
 
 function withFilter(builder: Knex.QueryBuilder, filter?: Filter) {


### PR DESCRIPTION
This is so we can set these indicators to include = 1 but still not
show them in the original app