### PR TITLE
Do not filter unitNames as much

### DIFF
--- a/src/models/data/unitNames.ts
+++ b/src/models/data/unitNames.ts
@@ -33,7 +33,11 @@ export const distinctUnitNamesRegister = (
     .from("agg_data")
     .leftJoin("ind", "agg_data.ind_id", "ind.id")
     .where("include", 1)
-    .whereRaw("denominator >= min_denominator")
+    .where(function () {
+      this.whereRaw("denominator >= min_denominator").orWhereNull(
+        "min_denominator"
+      );
+    })
     .where(function () {
       this.where("dg", ">=", 0.7).orWhereNull("dg");
     })


### PR DESCRIPTION
Data for units with min_denominator === null was filtered out.
Closes #347